### PR TITLE
added pianokeys to demo

### DIFF
--- a/docs-src/assets/css/style.css
+++ b/docs-src/assets/css/style.css
@@ -72,3 +72,8 @@ input {
     margin-top: 32px;
     text-align: left;
 }
+
+.showcase {
+    text-align: left;
+    font-size: 0.8em;
+}

--- a/docs-src/assets/index.html
+++ b/docs-src/assets/index.html
@@ -35,6 +35,7 @@
 
         <div class="output">
             <div data-output="normalized">-</div>
+            <div data-output="pianokeys"></div>
         </div>
 
         <div class="output-details hidden">

--- a/docs-src/assets/index.html
+++ b/docs-src/assets/index.html
@@ -35,7 +35,6 @@
 
         <div class="output">
             <div data-output="normalized">-</div>
-            <div data-output="pianokeys"></div>
         </div>
 
         <div class="output-details hidden">
@@ -48,6 +47,15 @@
             <div class="output-json">
                 <strong>Json: </strong><br/><pre data-output="json">-</pre>
             </div>
+        </div>
+
+        <div class="showcase">
+            <h2>Integration examples</h2>
+            <p>Please find below examples of how <i>Chord-symbol</i> can be used with other libs. If you want your library to be featured here, feel free to <a href="https://github.com/no-chris/chord-symbol/">submit a PR</a>.</p>
+            <h3>Custom piano keys</h3>
+            <p>A web component for creating custom HTML elements that depict piano keys. <a href="https://github.com/jutunen/custom-piano-keys">https://github.com/jutunen/custom-piano-keys</a>.</p>
+            <p><i>Chord-symbol</i> output data is used as an input to <i>Custom piano keys</i>.</p>
+            <div data-output="pianokeys"></div>
         </div>
 
     </div>

--- a/docs-src/src/index.js
+++ b/docs-src/src/index.js
@@ -1,5 +1,3 @@
-/*eslint complexity: ["error", 12]*/
-
 import { parseChord, chordRendererFactory } from '../../src/index';
 import 'custom-piano-keys';
 
@@ -9,7 +7,6 @@ const renderChordShort = chordRendererFactory({ useShortNamings: true });
 const chordInput = document.getElementById('chordInput');
 
 const normalized = document.querySelector('[data-output="normalized"]');
-const pianokeysDiv = document.querySelector('[data-output="pianokeys"]');
 const normalizedShort = document.querySelector('[data-output="normalizedShort"]');
 const intervals = document.querySelector('[data-output="intervals"]');
 const json = document.querySelector('[data-output="json"]');
@@ -19,6 +16,34 @@ let input;
 let chord;
 let symbolNormalized;
 let symbolShort;
+
+chordInput.addEventListener('keyup', () => {
+	input = chordInput.value;
+	chord = parseChord(input);
+
+	symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
+	symbolShort = (!chord) ? '' : renderChordShort(chord);
+
+	if (!chord) {
+		outputDetails.classList.add('hidden');
+	} else {
+		outputDetails.classList.remove('hidden');
+	}
+
+	normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
+	normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
+	intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
+	json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
+
+	updatePianoKeys(chord);
+});
+
+
+
+// Custom piano keys
+// https://github.com/jutunen/custom-piano-keys
+const pianokeysDiv = document.querySelector('[data-output="pianokeys"]');
+
 let mappedNotes;
 let markedKeys;
 let pianokeys;
@@ -30,14 +55,10 @@ function myReducer(total, item) {
 	return total + ' ' + item;
 }
 
-chordInput.addEventListener('keyup', () => {
-
+function updatePianoKeys() {
 	if(pianokeysDiv.firstChild) {
 		pianokeysDiv.firstChild.remove();
 	}
-
-	input = chordInput.value;
-	chord = parseChord(input);
 	if(chord) {
 		rootNoteIndex = rootNotes.indexOf(chord.normalized.rootNote);
 		if(rootNoteIndex !== -1) {
@@ -53,18 +74,4 @@ chordInput.addEventListener('keyup', () => {
 			pianokeysDiv.appendChild(pianokeys);
 		}
 	}
-
-	symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
-	symbolShort = (!chord) ? '' : renderChordShort(chord);
-
-	if (!chord) {
-		outputDetails.classList.add('hidden');
-	} else {
-		outputDetails.classList.remove('hidden');
-	}
-
-	normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
-	normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
-	intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
-	json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
-});
+}

--- a/docs-src/src/index.js
+++ b/docs-src/src/index.js
@@ -1,5 +1,5 @@
 import { parseChord, chordRendererFactory } from '../../src/index';
-import {Pianokeys} from 'custom-piano-keys'
+import 'custom-piano-keys';
 
 const renderChordNormalized = chordRendererFactory();
 const renderChordShort = chordRendererFactory({ useShortNamings: true });
@@ -25,44 +25,44 @@ let rootNoteIndex;
 let octaveCount;
 
 function myReducer(total, item) {
-    return total + " " + item;
+	return total + ' ' + item;
 }
 
 chordInput.addEventListener('keyup', () => {
 
-  if(pianokeysDiv.firstChild) {
-    pianokeysDiv.firstChild.remove()
-  }
+	if(pianokeysDiv.firstChild) {
+		pianokeysDiv.firstChild.remove();
+	}
 
-  input = chordInput.value;
-  chord = parseChord(input);
-  if(chord) {
-    rootNoteIndex = rootNotes.indexOf(chord.normalized.rootNote)
-    if(rootNoteIndex !== -1) {
-      mappedNotes = chord.normalized.semitones.map(x => x + 1 + rootNoteIndex)
-      octaveCount = 1
-      if(mappedNotes.some(x => x > 12)) {
-        octaveCount = 2
-      }
-      markedKeys = mappedNotes.reduce(myReducer,"").trim()
-      pianokeys = document.createElement("custom-piano-keys")
-      pianokeys.setAttribute("marked-keys", markedKeys)
-      pianokeys.setAttribute("oct-count", octaveCount)
-      pianokeysDiv.appendChild(pianokeys)
-    }
-  }
+	input = chordInput.value;
+	chord = parseChord(input);
+	if(chord) {
+		rootNoteIndex = rootNotes.indexOf(chord.normalized.rootNote);
+		if(rootNoteIndex !== -1) {
+			mappedNotes = chord.normalized.semitones.map(x => x + 1 + rootNoteIndex);
+			octaveCount = 1;
+			if(mappedNotes.some(x => x > 12)) {
+				octaveCount = 2;
+			}
+			markedKeys = mappedNotes.reduce(myReducer,'').trim();
+			pianokeys = document.createElement('custom-piano-keys');
+			pianokeys.setAttribute('marked-keys', markedKeys);
+			pianokeys.setAttribute('oct-count', octaveCount);
+			pianokeysDiv.appendChild(pianokeys);
+		}
+	}
 
-  symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
-  symbolShort = (!chord) ? '' : renderChordShort(chord);
+	symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
+	symbolShort = (!chord) ? '' : renderChordShort(chord);
 
-  if (!chord) {
-    outputDetails.classList.add('hidden');
-  } else {
-    outputDetails.classList.remove('hidden');
-  }
+	if (!chord) {
+		outputDetails.classList.add('hidden');
+	} else {
+		outputDetails.classList.remove('hidden');
+	}
 
-  normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
-  normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
-  intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
-  json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
+	normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
+	normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
+	intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
+	json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
 });

--- a/docs-src/src/index.js
+++ b/docs-src/src/index.js
@@ -1,4 +1,5 @@
 import { parseChord, chordRendererFactory } from '../../src/index';
+import {Pianokeys} from 'custom-piano-keys'
 
 const renderChordNormalized = chordRendererFactory();
 const renderChordShort = chordRendererFactory({ useShortNamings: true });
@@ -6,6 +7,7 @@ const renderChordShort = chordRendererFactory({ useShortNamings: true });
 const chordInput = document.getElementById('chordInput');
 
 const normalized = document.querySelector('[data-output="normalized"]');
+const pianokeysDiv = document.querySelector('[data-output="pianokeys"]');
 const normalizedShort = document.querySelector('[data-output="normalizedShort"]');
 const intervals = document.querySelector('[data-output="intervals"]');
 const json = document.querySelector('[data-output="json"]');
@@ -15,22 +17,52 @@ let input;
 let chord;
 let symbolNormalized;
 let symbolShort;
+let mappedNotes;
+let markedKeys;
+let pianokeys;
+let rootNotes = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+let rootNoteIndex;
+let octaveCount;
+
+function myReducer(total, item) {
+    return total + " " + item;
+}
 
 chordInput.addEventListener('keyup', () => {
-	input = chordInput.value;
-	chord = parseChord(input);
 
-	symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
-	symbolShort = (!chord) ? '' : renderChordShort(chord);
+  if(pianokeysDiv.firstChild) {
+    pianokeysDiv.firstChild.remove()
+  }
 
-	if (!chord) {
-		outputDetails.classList.add('hidden');
-	} else {
-		outputDetails.classList.remove('hidden');
-	}
+  input = chordInput.value;
+  chord = parseChord(input);
+  if(chord) {
+    rootNoteIndex = rootNotes.indexOf(chord.normalized.rootNote)
+    if(rootNoteIndex !== -1) {
+      mappedNotes = chord.normalized.semitones.map(x => x + 1 + rootNoteIndex)
+      octaveCount = 1
+      if(mappedNotes.some(x => x > 12)) {
+        octaveCount = 2
+      }
+      markedKeys = mappedNotes.reduce(myReducer,"").trim()
+      pianokeys = document.createElement("custom-piano-keys")
+      pianokeys.setAttribute("marked-keys", markedKeys)
+      pianokeys.setAttribute("oct-count", octaveCount)
+      pianokeysDiv.appendChild(pianokeys)
+    }
+  }
 
-	normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
-	normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
-	intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
-	json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
+  symbolNormalized = (!chord) ? '' : renderChordNormalized(chord);
+  symbolShort = (!chord) ? '' : renderChordShort(chord);
+
+  if (!chord) {
+    outputDetails.classList.add('hidden');
+  } else {
+    outputDetails.classList.remove('hidden');
+  }
+
+  normalized.textContent 		= (!chord) ? '-' : symbolNormalized;
+  normalizedShort.textContent = (symbolNormalized === symbolShort) ? '' : 'alternate: ' + symbolShort;
+  intervals.textContent 		= (!chord) ? '-' : chord.normalized.intervals.join('-');
+  json.textContent 			= (!chord) ? '-' : JSON.stringify(chord, null, 4);
 });

--- a/docs-src/src/index.js
+++ b/docs-src/src/index.js
@@ -1,3 +1,5 @@
+/*eslint complexity: ["error", 12]*/
+
 import { parseChord, chordRendererFactory } from '../../src/index';
 import 'custom-piano-keys';
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "core-js": "^3.2.1",
+    "custom-piano-keys": "0.0.10",
     "lodash": "^4.17.15"
   },
   "scripts": {


### PR DESCRIPTION
This works at least with basic chords. Assuming that semitones can not be negative. Importing custom-piano-keys will cause NotSupportedError because customElements.define() is called twice --> second call causes the error. I will try to fix that and publish a new version of custom-piano-keys soon.