### PR TITLE
parser config in Chord Object should have type ParserConfiguration

### DIFF
--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -6,7 +6,7 @@
  * If you need to trace what has generated a given chord, you'll find it here.
  * @property {NormalizedChord} normalized - abstract representation of the chord based on its intervals.
  * @property {FormattedChord} formatted - pre-rendering of the normalized chord.
- * @property {Object} parserConfiguration - configuration passed to the parser on chord creation.
+ * @property {ParserConfiguration} parserConfiguration - configuration passed to the parser on chord creation.
  */
 
 /**
@@ -95,4 +95,3 @@
  * @property {Boolean} [useFlats=false] - prefer flats for transposition/harmonization
  * @property {('text'|'raw')} [printer='text'] - the printer to use for the rendering. 'text' returns a string, 'raw' the processed chord object.
  */
-

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,7 +30,7 @@ type Chord = {
     /**
      * - configuration passed to the parser on chord creation.
      */
-    parserConfiguration: any;
+    parserConfiguration: ParserConfiguration;
 };
 /**
  * The source from which the chord structure has been built


### PR DESCRIPTION
Was this intentional?