### PR TITLE
ship types with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   ],
   "files": [
     "lib",
-    "src"
+    "src",
+    "types"
   ],
   "types": "types/index.d.ts"
 }


### PR DESCRIPTION
I used to install from my local directory, but now that types are officially out with 1.1.0, I installed from npm this morning. The types directory didn't get to npm, so I got multiple "types aren't installed" errors. Manually copying types to node_modules fixed the issue.
![image](https://user-images.githubusercontent.com/35939574/97179848-b2974980-176f-11eb-8df4-7715a185a9cc.png)
This is on runkit: https://npm.runkit.com/chord-symbol