### PR TITLE
fix(parser): Always consider #11 and b13 as an alteration

### DIFF
--- a/src/parser/filters/formatSymbolParts.js
+++ b/src/parser/filters/formatSymbolParts.js
@@ -1,5 +1,3 @@
-import intervalsToSemitones from '../../dictionaries/intervalsToSemitones';
-
 import { qualities } from '../../dictionaries/qualities';
 import { hasNoneOf } from '../../helpers/hasElement';
 
@@ -76,7 +74,8 @@ function getChordChanges(chord) {
 	);
 
 	return [
-		...sortAddsAndAlterations(formattedAdds, chord.normalized.alterations),
+		...chord.normalized.alterations,
+		...formattedAdds,
 		...formattedOmits,
 	];
 }
@@ -99,17 +98,6 @@ function formatAdds(quality, adds) {
 			formatted += add === '7' ? chordChangesDescriptors.add7 : add;
 			return formatted;
 		});
-}
-
-function sortAddsAndAlterations(adds, alterations) {
-	return [...alterations, ...adds].sort((a, b) => {
-		return getSortableInterval(a) - getSortableInterval(b);
-	});
-}
-
-function getSortableInterval(interval) {
-	let sortable = interval.replace(/[^0-9b#]/g, '');
-	return intervalsToSemitones[sortable];
 }
 
 function formatOmits(omits) {

--- a/src/parser/filters/normalizeDescriptor.js
+++ b/src/parser/filters/normalizeDescriptor.js
@@ -275,15 +275,15 @@ function getAddsAndAlterations(chordIntervals, baseIntervals, quality) {
 
 function isAlteration(quality, interval) {
 	const qualityAlterations = {
-		[qualities.ma]: ['b5', '#5', '#11'],
-		[qualities.ma6]: ['b5', '#5', '#11'],
-		[qualities.ma7]: ['b5', '#5', '#11'],
+		[qualities.ma]: ['b5', '#5', '#11', 'b13'],
+		[qualities.ma6]: ['b5', '#5', '#11', 'b13'],
+		[qualities.ma7]: ['b5', '#5', '#11', 'b13'],
 		[qualities.dom7]: ['b5', '#5', 'b9', '#9', '#11', 'b13'],
 
-		[qualities.mi]: ['b5', '#5', 'b13'],
-		[qualities.mi6]: ['b5', '#5', 'b13'],
-		[qualities.mi7]: ['b5', '#5', 'b13'],
-		[qualities.miMa7]: ['b5', '#5', 'b13'],
+		[qualities.mi]: ['b5', '#5', '#11', 'b13'],
+		[qualities.mi6]: ['b5', '#5', '#11', 'b13'],
+		[qualities.mi7]: ['b5', '#5', '#11', 'b13'],
+		[qualities.miMa7]: ['b5', '#5', '#11', 'b13'],
 
 		[qualities.aug]: [],
 		[qualities.dim]: [],

--- a/tests/allChordsAndVariants.spec.js
+++ b/tests/allChordsAndVariants.spec.js
@@ -174,7 +174,7 @@ const allSrcSymbols = [
 	['CMA7(add 13)', 'C', ['1', '3', '5', '7', '13'], 'Cma7(add13)'],
 	['CMA13', 'C', ['1', '3', '5', '7', '9', '13'], 'Cma13'],
 	['CMA13(#11)', 'C', ['1', '3', '5', '7', '9', '#11', '13'], 'Cma13(#11)'],
-	['Bb(add 9,add b13)', 'Bb', ['1', '3', '9', 'b13'], 'Bb(add9,b13)'],
+	['Bb(add 9,add b13)', 'Bb', ['1', '3', '9', 'b13'], 'Bb(b13,add9)'], // b13 is considered an alteration and not an added
 	['A+(add b9,add #9)', 'A', ['1', '3', '#5', 'b9', '#9'], 'A+(add b9,#9)'],
 	['CMI7', 'C', ['1', 'b3', '5', 'b7'], 'Cmi7'],
 	['CMI7(omit 5)', 'C', ['1', 'b3', 'b7'], 'Cmi7(omit5)'],

--- a/tests/parser/filters/formatSymbolParts.spec.js
+++ b/tests/parser/filters/formatSymbolParts.spec.js
@@ -90,13 +90,15 @@ describe('normalizeDescriptor', () => {
 		['add4', 'Cadd4', 'sus', ['add3']],
 
 		['sort alt>add', 'C7b5(add13)', '7', ['b5', 'add13']],
+		['sort alt>add', 'C(b13,add9)', '', ['b13', 'add9']],
+		['sort alt>add', 'C(b6,#11)', '', ['#11', 'add b6']],
 		['sort alt>omit', 'C7b5(add13)', '7', ['b5', 'add13']],
 		['sort alt b>#', 'C7(#11,#9,b9,#5,b5)', '7', ['b5', '#5', 'b9', '#9', '#11']],
 
 		['add b9 with space', 'C(b9)', '', ['add b9']],
 		['add #9 with space', 'C(#9)', '', ['add #9']],
-		['add #11 with space', 'Cm(#11)', 'mi', ['add #11']],
-		['add b13 with space', 'C(b13)', '', ['add b13']],
+		['add #11 with space', 'Cdim(#11)', 'dim', ['add #11']],
+		['add b13 with space', 'Cdim(b13)', 'dim', ['add b13']],
 
 		['do not repeat add', 'C(add9,add13)', '', ['add9', '13']],
 		['do not repeat omit', 'C7(omit3,omit5)', '7', ['omit3', '5']],
@@ -109,10 +111,10 @@ describe('normalizeDescriptor', () => {
 		['#5 always alt (dom)', 'C7(#5)', '7', ['#5']],
 		['#5 always alt (mi7)', 'Cm7(#5)', 'mi7', ['#5']],
 		['#5 always alt (ma7)', 'CM7(#5)', 'ma7', ['#5']],
-		['#11 alt if major', 'C(#11)', '', ['#11']],
-		['#11 added if minor', 'Cm(#11)', 'mi', ['add #11']],
-		['b13 added if major', 'C(b13)', '', ['add b13']],
-		['b13 alt if minor', 'Cm(b13)', 'mi', ['b13']],
+		['#11 always alt (ma)', 'C(#11)', '', ['#11']],
+		['#11 always alt (mi)', 'Cm(#11)', 'mi', ['#11']],
+		['b13 always alt (ma)', 'C(b13)', '', ['b13']],
+		['b13 always alt (mi)', 'Cm(b13)', 'mi', ['b13']],
 		['dim b5', 'C°(b5)', 'dim', []], // has already b5
 		['dim #5 add', 'C°(#5)', 'dim', ['add #5']],
 		['dim b9 add', 'C°(b9)', 'dim', ['add b9']],

--- a/tests/parser/filters/normalizeDescriptor.spec.js
+++ b/tests/parser/filters/normalizeDescriptor.spec.js
@@ -91,7 +91,7 @@ describe('normalizeDescriptor', () => {
 		['alt + add', 'C7b5(add13)', { quality: 'dominant7', alterations: ['b5'], adds: ['13'] }],
 		['add + omit', 'C7(omit3,add13)', { quality: 'dominant7', adds: ['13'], omits: ['3'] }],
 		['alt + add + omit', 'C7omit3b5add13', { quality: 'dominant7', alterations: ['b5'], adds: ['13'], omits: ['3'] }],
-		['multiple adds, sorted', 'Cm(add13)add9addb6add#11', { quality: 'minor', adds: ['b6', '9', '#11', '13'] }],
+		['multiple adds, sorted', 'Cm(add13)add9addb6add11', { quality: 'minor', adds: ['b6', '9', '11', '13'] }],
 		['multiple alts, sorted', 'C7(#11,#9,b9,#5,b5)', { quality: 'dominant7', alterations: ['b5', '#5', 'b9', '#9', '#11'] }],
 		['add ma7', 'Cdim7(add ma7)', { quality: 'diminished7', adds: ['7'] }],
 		['minor + add3', 'Cm(add3)', { quality: 'minor', adds: ['3'] }],

--- a/tests/renderer/printer/raw.spec.js
+++ b/tests/renderer/printer/raw.spec.js
@@ -52,9 +52,9 @@ describe('raw printer', () => {
 	});
 
 	describe.each([
-		['Ch(#11,b13)', 0, 'none', false, 'Cmi7(b5,add #11,b13)'],
-		['Ch(#11,b13)', 2, 'none', true, 'Dm7(b5,add #11,b13)'],
-		['Ch(#11,b13)', 2, 'none', false, 'Dmi7(b5,add #11,b13)'],
+		['Ch(#11,b13)', 0, 'none', false, 'Cmi7(b5,#11,b13)'],
+		['Ch(#11,b13)', 2, 'none', true, 'Dm7(b5,#11,b13)'],
+		['Ch(#11,b13)', 2, 'none', false, 'Dmi7(b5,#11,b13)'],
 		['Ch(#11,b13)', 2, 'core', false, 'Dmi7(b5)'],
 		['Ch(#11,b13)', 4, 'max', false, 'Emi'],
 		['Ch(#11,b13)', 5, 'max', true, 'Fm'],


### PR DESCRIPTION
Also fix the sorting of the alterations and the addeds in the formatted
descriptor: all alterations should *always* come before the addeds and
not be mixed up with each others.

closes #386 