### PR TITLE
fix(chord-symbol): export TypeScript types for parser and renderer factory functions

### DIFF
--- a/packages/chord-symbol/types/index.d.ts
+++ b/packages/chord-symbol/types/index.d.ts
@@ -1,12 +1,12 @@
 export {
-	chordParserFactory,
-	chordRendererFactory,
 	Chord,
 	ChordInput,
 	FormattedChord,
 	NormalizedChord,
 	ParserConfiguration,
 	RendererConfiguration,
+	chordParserFactory,
+	chordRendererFactory,
 };
 
 /**
@@ -269,3 +269,17 @@ type RendererConfiguration = {
  * Don't do that!
  */
 type customFilter = (arg0: Chord) => Chord;
+
+/**
+ * Create a chord parser function.
+ */
+declare function chordParserFactory(
+	configuration?: ParserConfiguration
+): (input: string) => Chord;
+
+/**
+ * Create a chord rendering function.
+ */
+declare function chordRendererFactory(
+	configuration?: RendererConfiguration
+): (chord: Chord) => string;


### PR DESCRIPTION
The modules declared in JSDoc comments do not appear to be used by TypeScript, so all typing information disappeared in 4.0.0-beta.1 when the exports were removed.

I've improved them a little, as the original code seemed to be auto-generated.