### PR TITLE
feat(chord-symbol): make the chord type a union

### DIFF
--- a/packages/chord-symbol/API.md
+++ b/packages/chord-symbol/API.md
@@ -25,8 +25,14 @@ Expose the chordRendererFactory() function</a></dt>
 ## Typedefs
 
 <dl>
+<dt><a href="#MaybeChord">MaybeChord</a> : <code><a href="#Chord">Chord</a></code> | <code><a href="#ChordParseFailure">ChordParseFailure</a></code></dt>
+<dd><p>An object that may be a chord data object or a chord parsing failure object.</p>
+</dd>
 <dt><a href="#Chord">Chord</a> : <code>Object</code></dt>
-<dd><p>A data object representing a chord. It is the result of the parsing operation and can be used for rendering.</p>
+<dd><p>A data object representing a chord. It is the result of a successful parsing operation and can be used for rendering.</p>
+</dd>
+<dt><a href="#ChordParseFailure">ChordParseFailure</a> : <code>Object</code></dt>
+<dd><p>An error object for a chord that could not be parsed.</p>
 </dd>
 <dt><a href="#ChordInput">ChordInput</a> : <code>Object</code></dt>
 <dd><p>The source from which the chord structure has been built</p>
@@ -102,11 +108,12 @@ Create a chord parser function
 
 <a name="chordParserFactory..parseChord"></a>
 
-### chordParserFactory~parseChord(symbol) ⇒ [<code>Chord</code>](#Chord) \| <code>Object</code>
+### chordParserFactory~parseChord(symbol) ⇒ [<code>MaybeChord</code>](#MaybeChord)
 Convert an input string into an abstract chord structure
 
 **Kind**: inner method of [<code>chordParserFactory</code>](#chordParserFactory)  
-**Returns**: [<code>Chord</code>](#Chord) \| <code>Object</code> - A chord object if the given string is successfully parsed. An object with an `error` property otherwise.  
+**Returns**: [<code>MaybeChord</code>](#MaybeChord) - A chord data object if the given string is successfully parsed.
+  A chord parse failure object with an `error` property otherwise.  
 <table>
   <thead>
     <tr>
@@ -158,10 +165,16 @@ Render a chord structure
     </tr>  </tbody>
 </table>
 
+<a name="MaybeChord"></a>
+
+## MaybeChord : [<code>Chord</code>](#Chord) \| [<code>ChordParseFailure</code>](#ChordParseFailure)
+An object that may be a chord data object or a chord parsing failure object.
+
+**Kind**: global typedef  
 <a name="Chord"></a>
 
 ## Chord : <code>Object</code>
-A data object representing a chord. It is the result of the parsing operation and can be used for rendering.
+A data object representing a chord. It is the result of a successful parsing operation and can be used for rendering.
 
 **Kind**: global typedef  
 **Properties**
@@ -174,20 +187,38 @@ A data object representing a chord. It is the result of the parsing operation an
   </thead>
   <tbody>
 <tr>
-    <td>[input]</td><td><code><a href="#ChordInput">ChordInput</a></code></td><td><p>information derived from the symbol given as an input.
+    <td>input</td><td><code><a href="#ChordInput">ChordInput</a></code></td><td><p>information derived from the symbol given as an input.
 If you need to trace what has generated a given chord, you&#39;ll find it here.</p>
 </td>
     </tr><tr>
-    <td>[normalized]</td><td><code><a href="#NormalizedChord">NormalizedChord</a></code></td><td><p>abstract representation of the chord based on its intervals.</p>
+    <td>normalized</td><td><code><a href="#NormalizedChord">NormalizedChord</a></code></td><td><p>abstract representation of the chord based on its intervals.</p>
 </td>
     </tr><tr>
-    <td>[formatted]</td><td><code><a href="#FormattedChord">FormattedChord</a></code></td><td><p>pre-rendering of the normalized chord.</p>
+    <td>formatted</td><td><code><a href="#FormattedChord">FormattedChord</a></code></td><td><p>pre-rendering of the normalized chord.</p>
 </td>
     </tr><tr>
-    <td>[parserConfiguration]</td><td><code><a href="#ParserConfiguration">ParserConfiguration</a></code></td><td><p>configuration passed to the parser on chord creation.</p>
+    <td>parserConfiguration</td><td><code><a href="#ParserConfiguration">ParserConfiguration</a></code></td><td><p>configuration passed to the parser on chord creation.</p>
 </td>
-    </tr><tr>
-    <td>[error]</td><td><code><a href="#ChordSymbolError">Array.&lt;ChordSymbolError&gt;</a></code></td><td><p>if defined, then the parsing failed and this array will contain the reason(s) why</p>
+    </tr>  </tbody>
+</table>
+
+<a name="ChordParseFailure"></a>
+
+## ChordParseFailure : <code>Object</code>
+An error object for a chord that could not be parsed.
+
+**Kind**: global typedef  
+**Properties**
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th><th>Type</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+<tr>
+    <td>error</td><td><code><a href="#ChordSymbolError">Array.&lt;ChordSymbolError&gt;</a></code></td><td><p>the reason(s) why the parsing failed.</p>
 </td>
     </tr>  </tbody>
 </table>

--- a/packages/chord-symbol/src/parser/chordParserFactory.js
+++ b/packages/chord-symbol/src/parser/chordParserFactory.js
@@ -23,7 +23,7 @@ import parseDescriptor from './filters/parseDescriptor';
 /**
  * Create a chord parser function
  * @param {ParserConfiguration} [parserConfiguration]
- * @returns {function(String): Chord}
+ * @returns {function(String): MaybeChord}
  */
 function chordParserFactory(parserConfiguration = {}) {
 	const allAltIntervals = ['b5', '#5', 'b9', '#9', '#11', 'b13'];
@@ -44,7 +44,8 @@ function chordParserFactory(parserConfiguration = {}) {
 	/**
 	 * Convert an input string into an abstract chord structure
 	 * @param {String} symbol - the chord symbol candidate
-	 * @returns {Chord|Object} A chord object if the given string is successfully parsed. An object with an `error` property otherwise.
+	 * @returns {MaybeChord} A chord data object if the given string is successfully parsed.
+	 *   A chord parse failure object with an `error` property otherwise.
 	 */
 	function parseChord(symbol) {
 		const allErrors = [];

--- a/packages/chord-symbol/src/typedefs.js
+++ b/packages/chord-symbol/src/typedefs.js
@@ -1,13 +1,24 @@
 /**
- * A data object representing a chord. It is the result of the parsing operation and can be used for rendering.
+ * An object that may be a chord data object or a chord parsing failure object.
+ * @typedef {(Chord|ChordParseFailure)} MaybeChord
+ */
+
+/**
+ * A data object representing a chord. It is the result of a successful parsing operation and can be used for rendering.
  * @typedef {Object} Chord
  * @type {Object}
- * @property {ChordInput} [input] - information derived from the symbol given as an input.
+ * @property {ChordInput} input - information derived from the symbol given as an input.
  * If you need to trace what has generated a given chord, you'll find it here.
- * @property {NormalizedChord} [normalized] - abstract representation of the chord based on its intervals.
- * @property {FormattedChord} [formatted] - pre-rendering of the normalized chord.
- * @property {ParserConfiguration} [parserConfiguration] - configuration passed to the parser on chord creation.
- * @property {ChordSymbolError[]} [error] - if defined, then the parsing failed and this array will contain the reason(s) why
+ * @property {NormalizedChord} normalized - abstract representation of the chord based on its intervals.
+ * @property {FormattedChord} formatted - pre-rendering of the normalized chord.
+ * @property {ParserConfiguration} parserConfiguration - configuration passed to the parser on chord creation.
+ */
+
+/**
+ * An error object for a chord that could not be parsed.
+ * @typedef {Object} ChordParseFailure
+ * @type {Object}
+ * @property {ChordSymbolError[]} error - the reason(s) why the parsing failed.
  */
 
 /**

--- a/packages/chord-symbol/types/index.d.ts
+++ b/packages/chord-symbol/types/index.d.ts
@@ -1,7 +1,9 @@
 export {
 	Chord,
 	ChordInput,
+	ChordParseFailure,
 	FormattedChord,
+	MaybeChord,
 	NormalizedChord,
 	ParserConfiguration,
 	RendererConfiguration,
@@ -10,30 +12,39 @@ export {
 };
 
 /**
- * A data object representing a chord. It is the result of the parsing operation and can be used for rendering.
+ * An object that may be a chord data object or a chord parsing failure object.
+ */
+type MaybeChord = Chord | ChordParseFailure;
+/**
+ * A data object representing a chord. It is the result of a successful parsing operation and can be used for rendering.
  */
 type Chord = {
 	/**
 	 * - information derived from the symbol given as an input.
 	 * If you need to trace what has generated a given chord, you'll find it here.
 	 */
-	input?: ChordInput;
+	input: ChordInput;
 	/**
 	 * - abstract representation of the chord based on its intervals.
 	 */
-	normalized?: NormalizedChord;
+	normalized: NormalizedChord;
 	/**
 	 * - pre-rendering of the normalized chord.
 	 */
-	formatted?: FormattedChord;
+	formatted: FormattedChord;
 	/**
 	 * - configuration passed to the parser on chord creation.
 	 */
-	parserConfiguration?: ParserConfiguration;
+	parserConfiguration: ParserConfiguration;
+};
+/**
+ * An error object for a chord that could not be parsed.
+ */
+type ChordParseFailure = {
 	/**
-	 * - if defined, then the parsing failed and this array will contain the reason(s) why
+	 * - the reason(s) why the parsing failed.
 	 */
-	error?: ChordSymbolError[];
+	error: ChordSymbolError[];
 };
 /**
  * The source from which the chord structure has been built
@@ -275,7 +286,7 @@ type customFilter = (arg0: Chord) => Chord;
  */
 declare function chordParserFactory(
 	configuration?: ParserConfiguration
-): (input: string) => Chord;
+): (input: string) => MaybeChord;
 
 /**
  * Create a chord rendering function.


### PR DESCRIPTION
~Instead of having a single object with all properties optional, use a `success` property to indicate whether the parsing was successful and use it to create a discriminated union between a data type and a failure type.~

Instead of having a single object with all properties optional, use two types (one for a successfully parsed chord and one for a failure object).
They can be discriminated between using the presence or absence of one of the properties.