### PR TITLE
Custom filter type improvements

### DIFF
--- a/packages/chord-symbol-ultimateguitar/src/chordSymbolUltimateGuitar.js
+++ b/packages/chord-symbol-ultimateguitar/src/chordSymbolUltimateGuitar.js
@@ -1,3 +1,7 @@
+/**
+ * Create a renderer filter function that modifies the rendered chord to be closer to the style used by Ultimate Guitar.
+ * @returns {import("../../chord-symbol").CustomFilter} The filter function
+ */
 const chordSymbolUltimateGuitar = () => {
 	return (chord) => {
 		chord.formatted.symbol = chord.formatted.symbol

--- a/packages/chord-symbol/API.md
+++ b/packages/chord-symbol/API.md
@@ -54,7 +54,7 @@ The <code>symbol</code> property contains the default assembled rendering</p>
 <dt><a href="#RendererConfiguration">RendererConfiguration</a> : <code>Object</code></dt>
 <dd><p>Configuration of the chord renderer</p>
 </dd>
-<dt><a href="#customFilter">customFilter</a> ⇒ <code><a href="#Chord">Chord</a></code> | <code>Null</code></dt>
+<dt><a href="#CustomFilter">CustomFilter</a> ⇒ <code><a href="#Chord">Chord</a></code> | <code>Null</code></dt>
 <dd><p>Custom filter applied during processing or rendering. Custom filters will be applied at the end of the processing pipe,
 after all built-in filters have been applied.</p>
 <p><strong>Parsing filters</strong></p>
@@ -393,7 +393,7 @@ the intervals that the <code>alt</code> modifier should yield
 If you would like <code>alt</code> to consistently yield a specific set of intervals, you can specify those here.</p>
 </td>
     </tr><tr>
-    <td>[customFilters]</td><td><code><a href="#customFilter">Array.&lt;customFilter&gt;</a></code></td><td><code>[]</code></td><td><p>custom filters applied during parsing</p>
+    <td>[customFilters]</td><td><code><a href="#CustomFilter">Array.&lt;CustomFilter&gt;</a></code></td><td><code>[]</code></td><td><p>custom filters applied during parsing</p>
 </td>
     </tr>  </tbody>
 </table>
@@ -469,14 +469,14 @@ Configuration of the chord renderer
     <code>auto</code> will use the same system in which the symbol was originally parsed.</p>
 </td>
     </tr><tr>
-    <td>[customFilters]</td><td><code><a href="#customFilter">Array.&lt;customFilter&gt;</a></code></td><td><code>[]</code></td><td><p>custom filters applied during rendering</p>
+    <td>[customFilters]</td><td><code><a href="#CustomFilter">Array.&lt;CustomFilter&gt;</a></code></td><td><code>[]</code></td><td><p>custom filters applied during rendering</p>
 </td>
     </tr>  </tbody>
 </table>
 
-<a name="customFilter"></a>
+<a name="CustomFilter"></a>
 
-## customFilter ⇒ [<code>Chord</code>](#Chord) \| <code>Null</code>
+## CustomFilter ⇒ [<code>Chord</code>](#Chord) \| <code>Null</code>
 Custom filter applied during processing or rendering. Custom filters will be applied at the end of the processing pipe,
 after all built-in filters have been applied.
 

--- a/packages/chord-symbol/src/typedefs.js
+++ b/packages/chord-symbol/src/typedefs.js
@@ -87,7 +87,7 @@
  * Since using the `C7alt` symbol is a way to leave some room for interpretation by the player, Chord-symbol offer the possibility to declare what are
  * the intervals that the `alt` modifier should yield
  * If you would like `alt` to consistently yield a specific set of intervals, you can specify those here.
- * @property {customFilter[]} [customFilters=[]] - custom filters applied during parsing
+ * @property {CustomFilter[]} [customFilters=[]] - custom filters applied during parsing
  */
 
 /**
@@ -117,7 +117,7 @@
  * @property {('text'|'raw')} [printer='text'] - the printer to use for the rendering. `text` returns a string, `raw` the processed chord object.
  * @property {('auto'|'english'|'german'|'latin')} [notationSystem='english'] - the notation system to use when rendering the chord.
  * 	`auto` will use the same system in which the symbol was originally parsed.
- * @property {customFilter[]} [customFilters=[]] - custom filters applied during rendering
+ * @property {CustomFilter[]} [customFilters=[]] - custom filters applied during rendering
  */
 
 /**
@@ -139,7 +139,7 @@
  * - To fail the rendering, simply return `null`.
  * Warning: if you throw an exception in a rendering filter, `ChordSymbol` will not catch it and the client code will need to handle it.
  * Don't do that!
- * @typedef {function(Chord): Chord} customFilter
+ * @typedef {function(Chord): Chord|Null} CustomFilter
  * @type {Function}
  * @param {Chord} chord - The chord object will be passed to the filter as the only parameter
  * @returns {Chord|Null} - Either the modified chord object, or `null` to cancel the processing and skip the remaining filters.

--- a/packages/chord-symbol/src/typedefs.js
+++ b/packages/chord-symbol/src/typedefs.js
@@ -139,7 +139,7 @@
  * - To fail the rendering, simply return `null`.
  * Warning: if you throw an exception in a rendering filter, `ChordSymbol` will not catch it and the client code will need to handle it.
  * Don't do that!
- * @typedef {function(Chord): Chord|Null} CustomFilter
+ * @typedef {function(Chord): (Chord|Null)} CustomFilter
  * @type {Function}
  * @param {Chord} chord - The chord object will be passed to the filter as the only parameter
  * @returns {Chord|Null} - Either the modified chord object, or `null` to cancel the processing and skip the remaining filters.

--- a/packages/chord-symbol/types/index.d.ts
+++ b/packages/chord-symbol/types/index.d.ts
@@ -2,6 +2,7 @@ export {
 	Chord,
 	ChordInput,
 	ChordParseFailure,
+	CustomFilter,
 	FormattedChord,
 	MaybeChord,
 	NormalizedChord,
@@ -191,7 +192,7 @@ type ParserConfiguration = {
 	/**
 	 * - custom filters applied during parsing
 	 */
-	customFilters?: customFilter[];
+	customFilters?: CustomFilter[];
 };
 /**
  * Description of an error that occurred during the parsing.
@@ -257,7 +258,7 @@ type RendererConfiguration = {
 	/**
 	 * - custom filters applied during rendering
 	 */
-	customFilters?: customFilter[];
+	customFilters?: CustomFilter[];
 };
 /**
  * Custom filter applied during processing or rendering. Custom filters will be applied at the end of the processing pipe,
@@ -279,7 +280,7 @@ type RendererConfiguration = {
  * Warning: if you throw an exception in a rendering filter, `ChordSymbol` will not catch it and the client code will need to handle it.
  * Don't do that!
  */
-type customFilter = (arg0: Chord) => Chord;
+type CustomFilter = (chord: Chord) => Chord | null;
 
 /**
  * Create a chord parser function.


### PR DESCRIPTION
Changes:

- Brought the TypeScript type up to date with the JSDoc one (included `null`
in the return type).
- Improved the JSDoc type (included `Null` in the return in the `@typedef` line). **Does this need parens?**
- Improved the parameter name in the TypeScript type.
- Capitalized the type name.
- Exported the TypeScript type for easing the typing of custom filter functions.
- Added a JSDoc comment to the Ultimate Guitar filter factory function.